### PR TITLE
Switch toc and header_alert order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       python: '3.6'
       env: TOXENV=py36
     - stage: test
-      python: 3.7-dev
+      python: '3.7'
       env: TOXENV=py37
     - stage: test
       python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       python: '3.6'
       env: TOXENV=py36
     - stage: test
-      python: '3.7'
+      python: 3.7-dev
       env: TOXENV=py37
     - stage: test
       python: '3.6'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.3.0 (2018-11-18)
+------------------
+
+* Switch order of optional ``toc`` and ``header_warning`` in rendered HTML for ``JiveContent.create_html_document()`` / ``JiveContent.update_html_document()``, so that warning is not hidden by long TOC.
+
 0.2.0 (2018-04-21)
 ------------------
 

--- a/jiveapi/content.py
+++ b/jiveapi/content.py
@@ -188,11 +188,11 @@ class JiveContent(object):
           Macros. Otherwise, they will not be processed by Jive.
         :type editable: bool
         :param toc: If True, insert the Jive RTE "Table of Contents" macro at
-          the beginning of the html. Setting this to True forces ``editable`` to
-          be True.
+          the beginning of the html, after header_alert (if specified). Setting
+          this to True forces ``editable`` to be True.
         :type toc: bool
         :param header_alert: If not None, insert a Jive RTE "Alert" macro at the
-          beginning of the html (after the Table of Contents, if present).
+          beginning of the html (before the Table of Contents, if present).
           Setting this to forces ``editable`` to be True. The value of this
           parameter can either be a string which will be used as the content of
           a "info" alert box, or a 2-tuple of the string alert box type (one of
@@ -291,11 +291,11 @@ class JiveContent(object):
           Macros. Otherwise, they will not be processed by Jive.
         :type editable: bool
         :param toc: If True, insert the Jive RTE "Table of Contents" macro at
-          the beginning of the html. Setting this to True forces ``editable`` to
-          be True.
+          the beginning of the html, after header_alert (if specified). Setting
+          this to True forces ``editable`` to be True.
         :type toc: bool
         :param header_alert: If not None, insert a Jive RTE "Alert" macro at the
-          beginning of the html (after the Table of Contents, if present).
+          beginning of the html (before the Table of Contents, if present).
           Setting this to forces ``editable`` to be True. The value of this
           parameter can either be a string which will be used as the content of
           a "info" alert box, or a 2-tuple of the string alert box type (one of
@@ -398,11 +398,11 @@ class JiveContent(object):
           Macros. Otherwise, they will not be processed by Jive.
         :type editable: bool
         :param toc: If True, insert the Jive RTE "Table of Contents" macro at
-          the beginning of the html. Setting this to True forces ``editable`` to
-          be True.
+          the beginning of the html, after header_alert (if specified). Setting
+          this to True forces ``editable`` to be True.
         :type toc: bool
         :param header_alert: If not None, insert a Jive RTE "Alert" macro at the
-          beginning of the html (after the Table of Contents, if present).
+          beginning of the html (before the Table of Contents, if present).
           Setting this to forces ``editable`` to be True. The value of this
           parameter can either be a string which will be used as the content of
           a "info" alert box, or a 2-tuple of the string alert box type (one of
@@ -438,6 +438,9 @@ class JiveContent(object):
             if jiveize:
                 logger.debug('Passing input HTML through jiveize_etree()')
                 doc = JiveContent.jiveize_etree(doc)
+            if toc:
+                logger.debug('Adding Jive RTM "Table of Contents" macro')
+                doc = JiveContent.etree_add_toc(doc)
             if header_alert is not None:
                 logger.debug(
                     'Adding Jive RTM "Alert" macro to header: %s', header_alert
@@ -452,9 +455,6 @@ class JiveContent(object):
                 doc = JiveContent.etree_add_alert(
                     doc, footer_alert, header=False
                 )
-            if toc:
-                logger.debug('Adding Jive RTM "Table of Contents" macro')
-                doc = JiveContent.etree_add_toc(doc)
             if handle_images:
                 logger.debug('Passing input HTML through _upload_images()')
                 doc, images = self._upload_images(doc, images)

--- a/jiveapi/tests/test_content.py
+++ b/jiveapi/tests/test_content.py
@@ -501,15 +501,15 @@ class TestDictForHtmlDocument(ContentTester):
         assert mocks['html_to_etree'].mock_calls == [call('body')]
         assert mocks['inline_css_etree'].mock_calls == [call(m_hte)]
         assert mocks['jiveize_etree'].mock_calls == [call(m_ice)]
-        # header gets applied before toc
+        # header goes above toc, so it gets applied after
         assert mocks['etree_add_toc'].mock_calls == [
-            call(m_eaa)
+            call(m_je)
         ]
         assert mocks['etree_add_alert'].mock_calls == [
-            call(m_je, 'foobarAlert', header=True)
+            call(m_eat, 'foobarAlert', header=True)
         ]
         assert mocks['_upload_images'].mock_calls == [
-            call(m_eat, {'input': 'images'})
+            call(m_eaa, {'input': 'images'})
         ]
         assert mock_tostring.mock_calls == [call(m_ui)]
         assert self.mockapi.mock_calls == []

--- a/jiveapi/version.py
+++ b/jiveapi/version.py
@@ -37,7 +37,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 #: Constant to hold this version of the package, used both in ``setup.py`` and
 #: anywhere in the code that reports the version.
-VERSION = '0.2.0'
+VERSION = '0.3.0'
 
 #: Constant to hold the project URL, used both in ``setup.py`` and anywhere in
 #: the code that reports the version.


### PR DESCRIPTION
Right now, if both ``toc`` and ``header_warning`` are specified on ``JiveContent.create_html_document()`` / ``JiveContent.update_html_document()``, a very long table of contents ends up hiding the header warning. Swap those so the warning is above the TOC.